### PR TITLE
Add service worker support

### DIFF
--- a/web/public/service-worker-custom.js
+++ b/web/public/service-worker-custom.js
@@ -1,0 +1,55 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.0.0/workbox-sw.js');
+
+// https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#registerRoute
+workbox.routing.registerRoute(
+  /index\.html/,
+  // https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.strategies
+  workbox.strategies.cacheFirst({
+    cacheName: 'workbox:html',
+  })
+);
+
+workbox.routing.registerRoute(
+  /\//,
+  // https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.strategies
+  workbox.strategies.cacheFirst({
+    cacheName: 'workbox:html',
+  })
+);
+
+workbox.routing.registerRoute(
+  new RegExp('.*\.js'),
+  workbox.strategies.networkFirst({
+    cacheName: 'workbox:js',
+  })
+);
+
+// CSS 
+workbox.routing.registerRoute(
+  // Cache CSS files
+  /.*\.css/,
+  // Use cache but update in the background ASAP
+  workbox.strategies.staleWhileRevalidate({
+    // Use a custom cache name
+    cacheName: 'workbox:css',
+  })
+);
+
+// Images
+workbox.routing.registerRoute(
+  // Cache image files
+  /.*\.(?:png|jpg|jpeg|svg|gif)/,
+  // Use the cache if it's available
+  workbox.strategies.cacheFirst({
+    // Use a custom cache name
+    cacheName: 'workbox:image',
+    plugins: [
+      new workbox.expiration.Plugin({
+        // Cache only 20 images
+        maxEntries: 20,
+        // Cache for a maximum of a week
+        maxAgeSeconds: 7 * 24 * 60 * 60,
+      })
+    ],
+  })
+);

--- a/web/public/service-worker-custom.js
+++ b/web/public/service-worker-custom.js
@@ -1,5 +1,9 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.0.0/workbox-sw.js');
 
+workbox.core.setCacheNameDetails({
+  suffix: "graphql-sandbox"
+});
+
 // https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#registerRoute
 workbox.routing.registerRoute(
   /index\.html/,

--- a/web/src/registerServiceWorker.js
+++ b/web/src/registerServiceWorker.js
@@ -19,7 +19,8 @@ const isLocalhost = Boolean(
 );
 
 export default function register() {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  // Always enable service worker
+  if ('serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
     if (publicUrl.origin !== window.location.origin) {
@@ -30,7 +31,7 @@ export default function register() {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker-custom.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.

--- a/web/src/view/ListUser.js
+++ b/web/src/view/ListUser.js
@@ -10,10 +10,10 @@ import { GET_USERS, DELETE_USER, UPDATE_USER } from '../queries'
 export const ListUser = () => {
   return (
     <Query query={GET_USERS} fetchPolicy="cache-and-network" errorPolicy="all">
-      {({ refetch, loading, error, data = {} }) => {
+      {({ networkStatus, refetch, loading, error, data = {} }) => {
 
         const { allUsers = [] } = data
-        if (error) return <p>`Error! ${error.message}`</p>
+        if (error && networkStatus === 8) console.info("Network error. Using cached data", allUsers)
 
         return (
           <div>


### PR DESCRIPTION
To fully present offline capabilities we need to cache static resources along with the sync data.
This change add service workers that can be used to test full offline mode in browser. 
I intentionally named worker differently to avoid clashes with existing workers that may been used before on that ports.

## How to use service worker

Make sure that worker is enabled and we use the right one (using private mode is good idea)
![screen shot 2018-10-19 at 11 46 14 am](https://user-images.githubusercontent.com/981838/47214157-fdb63f00-d394-11e8-8815-db70cd39e0f8.png)

Enable offline mode and enjoy seeing website working without internet connection

