### PR TITLE
Use id as cache object (force this state)

### DIFF
--- a/web/src/sdk/apolloClient.js
+++ b/web/src/sdk/apolloClient.js
@@ -23,7 +23,10 @@ export const setupApolloClient = async () => {
 
   const link = ApolloLink.from([offlineLink, conflictLink(), networkLink(), retryOnErrorLink(), httpLink])
 
-  const cache = new InMemoryCache()
+  const cache = new InMemoryCache({
+    // Use id as object for cache
+    dataIdFromObject: object => object.id
+  });
   const apolloClient = new ApolloClient({ link, cache })
   await persistCache({
     cache,


### PR DESCRIPTION
Use explicit ID for cache so we can rely on this on queries. 
Currently we rely on id field being present but we do not specify this as explicit cache key. 

Default is `id and _id` but we want to avoid exposing directly _id as this will match strongly mongodb and can lead to problems with optimistic response pruning. Settling with only id gives us standard we can support and ability to remap id's on the server to anything that makes sense for user needs.
