### PR TITLE
Add refetch

### DIFF
--- a/web/src/sdk/mutations/QueueMutationLink.js
+++ b/web/src/sdk/mutations/QueueMutationLink.js
@@ -60,7 +60,7 @@ export class QueueMutationLink extends ApolloLink {
       query.definitions = definitions
       let operationName = query.definitions[0].name.value
       let objectID = variables.id
-      if (this.queue.length > 0) {
+      if (this.queue.length > 0 && objectID) {
         this.queue.forEach((element, index) => {
           if(element.mutation.definitions[0].name.value === operationName && element.variables.id === objectID){
               let newOperation = deepmerge(element, {mutation: query, variables})

--- a/web/src/view/ListUser.js
+++ b/web/src/view/ListUser.js
@@ -76,8 +76,7 @@ class UserItem extends React.Component {
       }
     })
   }
-
-
+  
   onUpdate = async ({ item }) => {
     const { client } = this.props
     const { isOffline } = this.state
@@ -103,7 +102,10 @@ class UserItem extends React.Component {
           mutation: UPDATE_USER,
           variables,
           optimisticResponse,
-          errorPolicy: 'ignore'
+          errorPolicy: 'ignore',
+          refetchQueries: [{
+            query: GET_USERS
+          }]
         })
       }
       finally {


### PR DESCRIPTION
added refetchQueries to allow us to get the users after a mutation, thereby showing us the real users if a collision has occured.

ps based this off my branch from the other PR so ignore one of the file changes